### PR TITLE
Reworked links

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,13 +4,20 @@ import Layout from '../layouts/layout.astro';
 
 <Layout title="Whisky">
 	<main>
-		<div class="h-screen flex flex-col items-center justify-center">
+		<div class="h-screen flex flex-col gap-y-4 items-center justify-center">
 			<h1 class="text-8xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-amber-500 to-red-500">Get Whisky.</h1>
-			<a href="https://github.com/Whisky-App/Whisky/releases">
-				<div class="bg-amber-500 px-4 py-2 m-5 rounded-3xl transition duration-300 hover:ease-in-out hover:bg-gradient-to-br from-amber-500 to-red-500 hover:drop-shadow-xl hover:scale-105">
-					<p class="text-black text-lg font-bold">Download Latest</p>
-				</div>
-			</a>
+			<div class="flex flex-row gap-x-4">
+				<a href="https://github.com/Whisky-App/Whisky/releases/latest/download/Whisky.zip">
+					<div class="bg-amber-500 px-4 py-2 rounded-3xl transition duration-300 hover:ease-in-out hover:bg-gradient-to-br from-amber-500 to-red-500 hover:drop-shadow-xl hover:scale-105">
+						<p class="text-black text-lg text-center font-bold">Download Latest</p>
+					</div>
+				</a>
+				<a href="https://github.com/Whisky-App/Whisky/releases">
+					<div class="bg-amber-500 px-4 py-2 rounded-3xl transition duration-300 hover:ease-in-out hover:bg-gradient-to-br from-amber-500 to-red-500 hover:drop-shadow-xl hover:scale-105">
+						<p class="text-black text-lg text-center font-bold">See All Releases</p>
+					</div>
+				</a>
+			</div>
 		</div>
 	</main>
 </Layout>


### PR DESCRIPTION
- Changed the `Download Latest` button to download the latest version without redirecting to the GitHub Releases page
- Added a `See All Releases` button to redirect users to the GitHub Releases page